### PR TITLE
Flexibility to add already planned task

### DIFF
--- a/src/openagi/actions/tools/ddg_search.py
+++ b/src/openagi/actions/tools/ddg_search.py
@@ -3,7 +3,7 @@ from typing import Any
 from openagi.actions.base import BaseAction
 from pydantic import Field
 from duckduckgo_search import DDGS
-
+import logging
 
 class DuckDuckGoSearch(BaseAction):
     """Use this Action to search DuckDuckGo for a query."""
@@ -31,6 +31,10 @@ class DuckDuckGoSearch(BaseAction):
         return DDGS()
 
     def execute(self):
+        if self.max_results > 15:
+            logging.info("Over threshold value... Limiting the Max results to 15")
+            self.max_results = 15
+        
         result = self._get_ddgs().text(
             self.query,
             max_results=self.max_results,

--- a/src/openagi/agent.py
+++ b/src/openagi/agent.py
@@ -46,7 +46,7 @@ class Admin(BaseModel):
         description="Actions that the Agent supports", default_factory=list
     )
     max_iterations: int = Field(
-        default=20, description="Maximum number of steps to achieve the objective."
+        default=15, description="Maximum number of steps to achieve the objective."
     )
     output_format: OutputFormat = Field(
         default=OutputFormat.markdown,
@@ -366,11 +366,12 @@ class Admin(BaseModel):
         logging.debug(f"Execution Completed for Session ID - {self.memory.session_id}")
         return output
 
-    def run(self, query: str, description: str):
+    def run(self, query: str, description: str,planned_tasks: Optional[List[Dict]] = None):
         logging.info("Running Admin Agent...")
         logging.info(f"SessionID - {self.memory.session_id}")
 
-        planned_tasks = self.run_planner(query=query, descripton=description)
+        if planned_tasks is None:
+            planned_tasks = self.run_planner(query=query, descripton=description)
 
         logging.info("Tasks Planned...")
         logging.debug(f"{planned_tasks=}")


### PR DESCRIPTION
### To get planned task

```py
planner=TaskPlanner(llm = llm)

print(planner.plan(
    query="<query>",
    supported_actions = [DuckDuckGoSearch],
    description="<description>",
))
```

> Remember to use same set of actions inside Admin as well.

- Further limit the max_iterations to 15  

Output
<img width="1592" alt="Screenshot 2024-08-09 at 03 22 15" src="https://github.com/user-attachments/assets/0997e204-89e8-4300-bf38-715e4b20fdb2">

