### PR TITLE
Action Tool Configuration to accept API key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openagi"
-version = "0.2.9.5"
+version = "0.2.9.5b1"
 description = ""
 authors = ["AI Planet <tech@aiplanet.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openagi"
-version = "0.2.9.5b1"
+version = "0.2.9.5b2"
 description = ""
 authors = ["AI Planet <tech@aiplanet.com>"]
 readme = "README.md"

--- a/src/openagi/actions/tools/ddg_search.py
+++ b/src/openagi/actions/tools/ddg_search.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any,Dict
 from openagi.actions.base import BaseAction
 from pydantic import Field
 from duckduckgo_search import DDGS
@@ -40,6 +40,16 @@ class DuckDuckGoSearch(BaseAction):
             max_results=self.max_results,
         )
         return json.dumps(result)
+    
+    @classmethod
+    def from_user_config(cls, config: Dict[str, Any]) -> 'DuckDuckGoSearch':
+        """
+        Create a DuckDuckGoSearch instance from a user-provided configuration dictionary.
+        
+        :param config: A dictionary containing user-specified configuration.
+        :return: An instance of DuckDuckGoSearch.
+        """
+        return cls(**config)
 
 
 class DuckDuckGoNewsSearch(DuckDuckGoSearch):
@@ -50,3 +60,11 @@ class DuckDuckGoNewsSearch(DuckDuckGoSearch):
         return json.dumps(
             ddgs.news(keywords=self.query, max_results=(self.max_results)), indent=2
         )
+
+if __name__ == "__main__":
+    user_config = {
+        "query": "Python programming",
+        "max_results": 5
+    }
+    action = DuckDuckGoSearch
+    print(action.execute("query",max_results=15))

--- a/src/openagi/actions/tools/exasearch.py
+++ b/src/openagi/actions/tools/exasearch.py
@@ -12,7 +12,12 @@ class ConfigurableAction(BaseAction):
     config: ClassVar[Dict[str, Any]] = {}
 
     @classmethod
-    def set_config(cls, **kwargs):
+    def set_config(cls, *args, **kwargs):
+        if args:
+            if len(args) == 1 and isinstance(args[0], dict):
+                cls.config.update(args[0])
+            else:
+                raise ValueError("If using positional arguments, a single dictionary must be provided.")
         cls.config.update(kwargs)
 
     @classmethod
@@ -28,7 +33,7 @@ class ExaSearch(ConfigurableAction):
     def execute(self):
         api_key = self.get_config('api_key')
         if not api_key:
-            raise OpenAGIException("EXA API key not set. Use ExaSearch.set_config(api_key='your_key') to set the API key.")
+            raise OpenAGIException("API KEY NOT FOUND. Use ExaSearch.set_config(api_key='your_key') to set the API key.")
 
         exa = Exa(api_key=api_key)
         results = exa.search_and_contents(

--- a/src/openagi/actions/tools/exasearch.py
+++ b/src/openagi/actions/tools/exasearch.py
@@ -1,30 +1,45 @@
 from openagi.actions.base import BaseAction
-import os
 from pydantic import Field
 from openagi.exception import OpenAGIException
+from typing import ClassVar, Dict, Any
 
 try:
-   from exa_py import Exa
+    from exa_py import Exa
 except ImportError:
-  raise OpenAGIException("Install Exa Py with cmd `pip install exa_py`")
+    raise OpenAGIException("Install Exa Py with cmd `pip install exa_py`")
 
-class ExaSearch(BaseAction):
+class ConfigurableAction(BaseAction):
+    config: ClassVar[Dict[str, Any]] = {}
+
+    @classmethod
+    def set_config(cls, **kwargs):
+        cls.config.update(kwargs)
+
+    @classmethod
+    def get_config(cls, key: str, default: Any = None) -> Any:
+        return cls.config.get(key, default)
+
+class ExaSearch(ConfigurableAction):
     """
     Exa Search is a tool used when user needs to ask the question in terms of query to get response 
     """
-    query: str = Field(..., description="User query or question ")
-   
+    query: str = Field(..., description="User query or question")
+
     def execute(self):
-        api_key = os.environ["EXA_API_KEY"]
+        api_key = self.get_config('api_key')
+        if not api_key:
+            raise OpenAGIException("EXA API key not set. Use ExaSearch.set_config(api_key='your_key') to set the API key.")
+
+        exa = Exa(api_key=api_key)
+        results = exa.search_and_contents(
+            self.query,
+            text={"max_characters": 512},
+        )
         
-        exa = Exa(api_key = api_key)
-        results = exa.search_and_contents(self.query, 
-                                    text={"max_characters": 512}, 
-                                )
         content = ""
         for idx in results.results:
             content += idx.text.strip()
 
-        content = content.replace("<|endoftext|>","")
-        content = content.replace("NaN","")
+        content = content.replace("<|endoftext|>", "")
+        content = content.replace("NaN", "")
         return content

--- a/src/openagi/actions/tools/serper_search.py
+++ b/src/openagi/actions/tools/serper_search.py
@@ -9,7 +9,12 @@ class ConfigurableAction(BaseAction):
     config: ClassVar[Dict[str, Any]] = {}
 
     @classmethod
-    def set_config(cls, **kwargs):
+    def set_config(cls, *args, **kwargs):
+        if args:
+            if len(args) == 1 and isinstance(args[0], dict):
+                cls.config.update(args[0])
+            else:
+                raise ValueError("If using positional arguments, a single dictionary must be provided.")
         cls.config.update(kwargs)
 
     @classmethod
@@ -24,7 +29,7 @@ class SerperSearch(ConfigurableAction):
     def execute(self):
         api_key = self.get_config('api_key')
         if not api_key:
-            raise OpenAGIException("Serper API key not set. Use SerperSearch.set_config(api_key='your_key') to set the API key.")
+            raise OpenAGIException("API KEY NOT FOUND. Use SerperSearch.set_config(api_key='your_key') to set the API key.")
 
         conn = http.client.HTTPSConnection("google.serper.dev")
         payload = json.dumps({"q": self.query})

--- a/src/openagi/actions/tools/tavilyqasearch.py
+++ b/src/openagi/actions/tools/tavilyqasearch.py
@@ -7,18 +7,23 @@ try:
     from tavily import TavilyClient
 except ImportError:
     raise OpenAGIException("Install Tavily with cmd `pip install tavily-python`")
-
+    
 class ConfigurableAction(BaseAction):
     config: ClassVar[Dict[str, Any]] = {}
 
     @classmethod
-    def set_config(cls, **kwargs):
+    def set_config(cls, *args, **kwargs):
+        if args:
+            if len(args) == 1 and isinstance(args[0], dict):
+                cls.config.update(args[0])
+            else:
+                raise ValueError("If using positional arguments, a single dictionary must be provided.")
         cls.config.update(kwargs)
 
     @classmethod
     def get_config(cls, key: str, default: Any = None) -> Any:
         return cls.config.get(key, default)
-
+    
 class TavilyWebSearchQA(ConfigurableAction):
     """
     Tavily Web Search QA is a tool used when user needs to ask the question in terms of query to get response
@@ -28,7 +33,7 @@ class TavilyWebSearchQA(ConfigurableAction):
     def execute(self):
         api_key = self.get_config('api_key')
         if not api_key:
-            raise OpenAGIException("Tavily API key not set. Use TavilyWebSearchQA.set_config(api_key='your_key') to set the API key.")
+            raise OpenAGIException("API KEY NOT FOUND. Use TavilyWebSearchQA.set_config(api_key='your_key') to set the API key.")
         
         client = TavilyClient(api_key=api_key)
         response = client.qna_search(query=self.query)

--- a/src/openagi/actions/tools/tavilyqasearch.py
+++ b/src/openagi/actions/tools/tavilyqasearch.py
@@ -1,21 +1,35 @@
 from openagi.actions.base import BaseAction
-import os
 from pydantic import Field
 from openagi.exception import OpenAGIException
+from typing import ClassVar, Dict, Any
 
 try:
-   from tavily import TavilyClient
+    from tavily import TavilyClient
 except ImportError:
-  raise OpenAGIException("Install Tavily with cmd `pip install tavily-python`")
+    raise OpenAGIException("Install Tavily with cmd `pip install tavily-python`")
 
-class TavilyWebSearchQA(BaseAction):
+class ConfigurableAction(BaseAction):
+    config: ClassVar[Dict[str, Any]] = {}
+
+    @classmethod
+    def set_config(cls, **kwargs):
+        cls.config.update(kwargs)
+
+    @classmethod
+    def get_config(cls, key: str, default: Any = None) -> Any:
+        return cls.config.get(key, default)
+
+class TavilyWebSearchQA(ConfigurableAction):
     """
-    Tavily Web Search QA is a tool used when user needs to ask the question in terms of query to get response 
+    Tavily Web Search QA is a tool used when user needs to ask the question in terms of query to get response
     """
-    query: str = Field(..., description="User query or question ")
+    query: str = Field(..., description="User query or question")
 
     def execute(self):
-        api_key = os.environ['TAVILY_API_KEY']
+        api_key = self.get_config('api_key')
+        if not api_key:
+            raise OpenAGIException("Tavily API key not set. Use TavilyWebSearchQA.set_config(api_key='your_key') to set the API key.")
+        
         client = TavilyClient(api_key=api_key)
         response = client.qna_search(query=self.query)
         return response

--- a/src/openagi/actions/tools/webloader.py
+++ b/src/openagi/actions/tools/webloader.py
@@ -9,9 +9,7 @@ from sumy.summarizers.lsa import LsaSummarizer
 from sumy.utils import get_stop_words
 
 from openagi.actions.base import BaseAction
-
 nltk.download("punkt")
-
 
 class WebBaseContextTool(BaseAction):
     """

--- a/src/openagi/actions/tools/youtubesearch.py
+++ b/src/openagi/actions/tools/youtubesearch.py
@@ -1,15 +1,31 @@
 from openagi.actions.base import BaseAction
 from pydantic import Field
-from typing import Any
+from typing import Any, ClassVar, Dict
 from openagi.exception import OpenAGIException
 
 try:
-   import yt_dlp
-   from youtube_search import YoutubeSearch
+    import yt_dlp
+    from youtube_search import YoutubeSearch
 except ImportError:
-  raise OpenAGIException("Install YouTube transcript with cmd `pip install yt-dlp` and `pip install youtube-search`")
+    raise OpenAGIException("Install YouTube transcript with cmd `pip install yt-dlp` and `pip install youtube-search`")
 
-class YouTubeSearchTool(BaseAction):
+class ConfigurableAction(BaseAction):
+    config: ClassVar[Dict[str, Any]] = {}
+
+    @classmethod
+    def set_config(cls, *args, **kwargs):
+        if args:
+            if len(args) == 1 and isinstance(args[0], dict):
+                cls.config.update(args[0])
+            else:
+                raise ValueError("If using positional arguments, a single dictionary must be provided.")
+        cls.config.update(kwargs)
+
+    @classmethod
+    def get_config(cls, key: str, default: Any = None) -> Any:
+        return cls.config.get(key, default)
+
+class YouTubeSearchTool(ConfigurableAction):
     """Youtube Search Tool"""
 
     query: str = Field(
@@ -21,20 +37,21 @@ class YouTubeSearchTool(BaseAction):
     )
 
     def execute(self):
-        ydl_opts = {
+        ydl_opts = self.get_config('ydl_opts', {
             'quiet': True,
             'skip_download': True,
             'force_generic_extractor': True,
             'format': 'best'
-        }
+        })
+
         results = YoutubeSearch(self.query, max_results=self.max_results)
         response = results.to_dict()
         context = ""
         for ids in response:
-            url = "https://youtube.com/watch?v="+ids['id']
-            context += f"Title: {ids['title']}"
+            url = f"https://youtube.com/watch?v={ids['id']}"
+            context += f"Title: {ids['title']}\n"
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 info_dict = ydl.extract_info(url, download=False)
-                description = info_dict.get('description', None)
-                context += f"Description: {description} \n\n"
-        return context
+                description = info_dict.get('description', 'No description available')
+                context += f"Description: {description}\n\n"
+        return context.strip()

--- a/src/openagi/agent.py
+++ b/src/openagi/agent.py
@@ -104,7 +104,7 @@ class Admin(BaseModel):
         else:
             self.workers.extend(workers)
 
-    def run_planner(self, query: str, descripton: str):
+    def run_planner(self, query: str, description: str):
         if self.planner:
             if not getattr(self.planner, "llm", False):
                 setattr(self.planner, "llm", self.llm)
@@ -123,7 +123,7 @@ class Admin(BaseModel):
 
         return self.planner.plan(
             query=query,
-            description=descripton,
+            description=description,
             supported_actions=actions_dict,
             supported_workers=workers_dict,
         )
@@ -425,7 +425,7 @@ class Admin(BaseModel):
         logging.info(f"SessionID - {self.memory.session_id}")
 
         if planned_tasks is None:
-            planned_tasks = self.run_planner(query=query, descripton=description)
+            planned_tasks = self.run_planner(query=query, description=description)
 
         logging.info("Tasks Planned...")
         logging.debug(f"{planned_tasks=}")

--- a/src/openagi/worker.py
+++ b/src/openagi/worker.py
@@ -191,7 +191,10 @@ class Worker(BaseModel):
                         res = run_action(action_cls=act_cls, **params)
                         logging.info(f"Action '{act_cls.__name__}' completed. Result: {res}")
                     except Exception as e:
-                        logging.error(f"Error running action: {e}")
+                        if str(e).startswith("API KEY NOT FOUND"):
+                            logging.error(e)
+                            return {"error": "API KEY NOT FOUND. Please enter a valid API key before running this task."}, task
+                        
                         observations = f"Action: {action_json}\n{observations}. {e} Try to fix the error and try again. Ignore if already tried more than twice"
                         all_thoughts_and_obs.append(action_json)
                         all_thoughts_and_obs.append(observations)


### PR DESCRIPTION
- Except API key as the set_config function. Give flexibility to the user for modifying the variables for action tools. 
- Terminate the execute_task in workers if API not found. 