### PR TITLE
Added HuggingFaceTool to Explore HF Hub

### DIFF
--- a/src/openagi/actions/tools/huggingface.py
+++ b/src/openagi/actions/tools/huggingface.py
@@ -1,0 +1,29 @@
+from openagi.actions.base import ConfigurableAction
+from pydantic import Field
+import json
+
+try:
+    from huggingface_hub import HfApi
+except ImportError:
+    raise Exception("Install huggingface_hub with cmd `pip install huggingface`")
+
+class HuggingFaceTool(ConfigurableAction):
+    """
+    Tool for exploring Hugging Face models and datasets.
+    """
+    query: str = Field(..., description="Dataset or model name to search on Hugging Face.")
+
+    def execute(self) -> str:
+        api = HfApi()
+        results_dict = {}
+
+        models = api.list_models(search=self.query, limit=15)
+        datasets = api.list_datasets(search=self.query, limit=15)
+
+        for model in models:
+            results_dict[model.modelId] = f"https://huggingface.co/{model.modelId}"
+
+        for dataset in datasets:
+            results_dict[dataset.id] = f"https://huggingface.co/datasets/{dataset.id}"
+
+        return json.dumps(results_dict)


### PR DESCRIPTION
# Purpose
I made a new tool `openagi.actions.tools.huggingface.HuggingFaceTool` that can search for models and datasets across the HuggingFace Hub.

# Usage
```python
Agent = Worker(
    role = "Model and Dataset searching agent",
    instructions = "Search for the prompted model or dataset",
    actions = [HuggingFaceTool]
)
```

# Demo
```python

import os
from openagi.agent import Admin
from openagi.memory import Memory
from openagi.worker import Worker
from openagi.llms.gemini import GeminiModel
from openagi.planner.task_decomposer import TaskPlanner
from openagi.actions.tools.hf import HuggingFaceTool

os.environ['GOOGLE_API_KEY'] = "YOUR_GEMINI_API_KEY"
os.environ['Gemini_MODEL'] = "gemini-1.5-flash"
os.environ['Gemini_TEMP'] = "0.5"

config = GeminiModel.load_from_env_config()
llm = GeminiModel(config=config)



# Implementing HuggingFace Agent

search_agent = Worker(
    role="Search Agent",
    instructions="""
    Search for the prompted model or dataset.
    """,
    actions=[HuggingFaceTool]
)

admin = Admin(
    llm=llm,
    planner=TaskPlanner(
        autonomous=False,
        human_intervene=False
    ),
    memory=Memory(),
    verbose=True
)

admin.assign_workers([
    search_agent
])

response = admin.run(
    query="gemma model",
    description="",
)

print(response)
```

# Output
<img width="459" alt="677118ff5e14911d6219773f" src="https://github.com/user-attachments/assets/e59e156b-5c36-45b9-ae61-ca23d5af8541" />


@lucifertrj 